### PR TITLE
fix(create): generate .gitignore for scaffolded projects

### DIFF
--- a/packages/create/test/index.test.ts
+++ b/packages/create/test/index.test.ts
@@ -139,6 +139,7 @@ describe('create-vuetify matrix', () => {
       expect(fs.existsSync(join(projectPath, 'package.json'))).toBe(true)
       expect(fs.existsSync(join(projectPath, 'AGENTS.md'))).toBe(true)
       expect(fs.existsSync(join(projectPath, 'README.md'))).toBe(true)
+      expect(fs.existsSync(join(projectPath, '.gitignore'))).toBe(true)
 
       // Basic check for file structure
       if (args.includes('vue')) {

--- a/packages/shared/src/functions/scaffold.ts
+++ b/packages/shared/src/functions/scaffold.ts
@@ -7,7 +7,7 @@ import { applyFeatures } from '../features'
 import { convertProjectToJS } from '../utils/convertProjectToJS'
 import { getTemplateSource } from '../utils/getTemplateSource'
 import { installDependencies } from '../utils/installDependencies'
-import { getProjectAgentsMd, getProjectReadmeMd } from '../utils/projectDocs'
+import { getProjectAgentsMd, getProjectGitignore, getProjectReadmeMd } from '../utils/projectDocs'
 
 export interface ScaffoldOptions {
   cwd: string
@@ -260,6 +260,13 @@ export async function scaffold (options: ScaffoldOptions, callbacks: ScaffoldCal
 
   fs.writeFileSync(join(projectRoot, 'AGENTS.md'), getProjectAgentsMd(projectDocsOptions))
   fs.writeFileSync(join(projectRoot, 'README.md'), getProjectReadmeMd(projectDocsOptions))
+
+  // Templates can't ship a `.gitignore` (it would be stripped by tooling that
+  // packs them), so generate one unless the template already provided it.
+  const gitignorePath = join(projectRoot, '.gitignore')
+  if (!existsSync(gitignorePath)) {
+    fs.writeFileSync(gitignorePath, getProjectGitignore(projectDocsOptions))
+  }
 
   if (install && packageManager) {
     callbacks.onInstallStart?.(packageManager)

--- a/packages/shared/src/utils/projectDocs.ts
+++ b/packages/shared/src/utils/projectDocs.ts
@@ -118,6 +118,65 @@ function dlxCommand (pm: string, pkg: string) {
   return `npx -y ${pkg}`
 }
 
+export function getProjectGitignore (options: ProjectDocsOptions) {
+  if (options.platform === 'nuxt') {
+    return `# Nuxt dev/build outputs
+.output
+.data
+.nuxt
+.nitro
+.cache
+dist
+
+# Node dependencies
+node_modules
+
+# Logs
+logs
+*.log
+
+# Misc
+.DS_Store
+.fleet
+.idea
+
+# Local env files
+.env
+.env.*
+!.env.example
+`
+  }
+
+  return `# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+.DS_Store
+dist
+dist-ssr
+coverage
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+*.tsbuildinfo
+`
+}
+
 export function getProjectAgentsMd (options: ProjectDocsOptions) {
   const pm = getPackageManager(options.packageManager)
   const enabledFeatures = options.features.length > 0


### PR DESCRIPTION
## Fixes #14

### Problem
`npm create vuetify@latest` produced projects **without a `.gitignore`**, so `node_modules`, build output (`dist`/`.nuxt`/`.output`), and local env files were tracked by default.

### Root cause
The templates ship no `.gitignore` file, and `scaffold()` never generated one. Templates can't reliably carry a `.gitignore` either (it gets stripped/renamed when the template is packed).

### Fix
Generate a platform-appropriate `.gitignore` in `scaffold()`, alongside the existing `README.md`/`AGENTS.md` generation:

- **Vue (Vite)** — logs, `node_modules`, `dist`, `*.local`, editor dirs (keeps the `.vscode/extensions.json` exception), `*.tsbuildinfo`.
- **Nuxt** — `.nuxt`, `.output`, `.nitro`, `.data`, `.cache`, `node_modules`, local env files.

It skips writing if a template ever provides its own `.gitignore`.

### Verification
- Added a `.gitignore` existence assertion to the create matrix tests — all 10 pass.
- Manually verified a real Vue and Nuxt scaffold each emit the correct `.gitignore`.
