### PR TITLE
fix(create): apply features after converting project to JavaScript

### DIFF
--- a/packages/create/test/index.test.ts
+++ b/packages/create/test/index.test.ts
@@ -97,6 +97,8 @@ describe('create-vuetify matrix', () => {
   const matrix = [
     // Vue + JS
     { name: 'vue-js', platform: 'vue', args: ['--platform=vue', '--no-typescript', '--features='] },
+    // Vue + JS + Router + features (regression: features must apply to the converted JS project)
+    { name: 'vue-js-all', platform: 'vue', args: ['--platform=vue', '--no-typescript', '--router=router', '--features=pinia,eslint,i18n'] },
     // Vue + TS
     { name: 'vue-ts', platform: 'vue', args: ['--platform=vue', '--typescript', '--features='] },
     // Vue + TS + Router

--- a/packages/shared/src/features/i18n.ts
+++ b/packages/shared/src/features/i18n.ts
@@ -10,8 +10,6 @@ import rootPkg from './dependencies/package.json' with { type: 'json' }
 export const i18n: Feature = {
   name: 'i18n',
   apply: async ({ cwd, pkg, isTypescript, isNuxt }) => {
-    const ext = isTypescript ? 'ts' : 'js'
-
     if (isNuxt) {
       pkg.dependencies ??= {}
       pkg.dependencies['@nuxtjs/i18n'] = rootPkg.dependencies['@nuxtjs/i18n']
@@ -34,7 +32,7 @@ export const i18n: Feature = {
       await writeFile(configPath, mod.generate().code)
 
       // Create i18n.config.ts
-      await writeFile(join(cwd, `i18n.config.${ext}`), getNuxtI18nConfig(isTypescript))
+      await writeFile(join(cwd, 'i18n.config.ts'), getNuxtI18nConfig(isTypescript))
     } else {
       pkg.dependencies ??= {}
       pkg.dependencies['vue-i18n'] = rootPkg.dependencies['vue-i18n']
@@ -43,10 +41,10 @@ export const i18n: Feature = {
       if (!existsSync(join(cwd, 'src/plugins'))) {
         mkdirSync(join(cwd, 'src/plugins'), { recursive: true })
       }
-      await writeFile(join(cwd, `src/plugins/i18n.${ext}`), getVueI18nContent(isTypescript))
+      await writeFile(join(cwd, 'src/plugins/i18n.ts'), getVueI18nContent(isTypescript))
 
       // Register in plugins/index.ts
-      const pluginsPath = join(cwd, `src/plugins/index.${ext}`)
+      const pluginsPath = join(cwd, 'src/plugins/index.ts')
       if (existsSync(pluginsPath)) {
         const mod = await loadFile(pluginsPath)
 

--- a/packages/shared/src/features/pinia.ts
+++ b/packages/shared/src/features/pinia.ts
@@ -10,8 +10,6 @@ import rootPkg from './dependencies/package.json' with { type: 'json' }
 export const pinia: Feature = {
   name: 'pinia',
   apply: async ({ cwd, pkg, isTypescript, isNuxt }) => {
-    const ext = isTypescript ? 'ts' : 'js'
-
     if (isNuxt) {
       pkg.dependencies ??= {}
       pkg.devDependencies ??= {}
@@ -39,7 +37,7 @@ export const pinia: Feature = {
       if (!existsSync(join(cwd, appPath, 'stores'))) {
         mkdirSync(join(cwd, appPath, 'stores'), { recursive: true })
       }
-      await writeFile(join(cwd, appPath, `stores/app.${ext}`), getStoreContent(isTypescript))
+      await writeFile(join(cwd, appPath, 'stores/app.ts'), getStoreContent(isTypescript))
     } else {
       pkg.dependencies ??= {}
       pkg.dependencies['pinia'] = rootPkg.dependencies.pinia
@@ -48,10 +46,10 @@ export const pinia: Feature = {
       if (!existsSync(join(cwd, 'src/stores'))) {
         mkdirSync(join(cwd, 'src/stores'), { recursive: true })
       }
-      await writeFile(join(cwd, `src/stores/app.${ext}`), getStoreContent(isTypescript))
+      await writeFile(join(cwd, 'src/stores/app.ts'), getStoreContent(isTypescript))
 
       // Update plugins/index.ts
-      const pluginsPath = join(cwd, `src/plugins/index.${ext}`)
+      const pluginsPath = join(cwd, 'src/plugins/index.ts')
       const mod = await loadFile(pluginsPath)
 
       mod.imports.$prepend({

--- a/packages/shared/src/features/router.ts
+++ b/packages/shared/src/features/router.ts
@@ -12,7 +12,6 @@ export const router: Feature = {
   apply: async ({ cwd, pkg, isTypescript, type }) => {
     await installFeature('router', cwd, type)
 
-    const ext = isTypescript ? 'ts' : 'js'
     pkg.dependencies = pkg.dependencies || {}
     pkg.dependencies['vue-router'] = rootPkg.dependencies['vue-router']
 
@@ -21,10 +20,10 @@ export const router: Feature = {
     if (!existsSync(join(cwd, 'src/router'))) {
       mkdirSync(join(cwd, 'src/router'), { recursive: true })
     }
-    await writeFile(join(cwd, `src/router/index.${ext}`), routerContent)
+    await writeFile(join(cwd, 'src/router/index.ts'), routerContent)
 
     // Update plugins/index.ts
-    const pluginsPath = join(cwd, `src/plugins/index.${ext}`)
+    const pluginsPath = join(cwd, 'src/plugins/index.ts')
     const mod = await loadFile(pluginsPath)
 
     mod.imports.$prepend({
@@ -58,7 +57,6 @@ export const fileRouter: Feature = {
   apply: async ({ cwd, pkg, isTypescript, type }) => {
     await installFeature('file-router', cwd, type)
 
-    const ext = isTypescript ? 'ts' : 'js'
     pkg.dependencies = pkg.dependencies || {}
     pkg.dependencies['vue-router'] = rootPkg.dependencies['vue-router']
 
@@ -67,10 +65,10 @@ export const fileRouter: Feature = {
     if (!existsSync(join(cwd, 'src/router'))) {
       mkdirSync(join(cwd, 'src/router'), { recursive: true })
     }
-    await writeFile(join(cwd, `src/router/index.${ext}`), routerContent)
+    await writeFile(join(cwd, 'src/router/index.ts'), routerContent)
 
     // Update plugins/index.ts
-    const pluginsPath = join(cwd, `src/plugins/index.${ext}`)
+    const pluginsPath = join(cwd, 'src/plugins/index.ts')
     const mod = await loadFile(pluginsPath)
 
     mod.imports.$prepend({
@@ -86,8 +84,8 @@ export const fileRouter: Feature = {
 
     await writeFile(pluginsPath, mod.generate().code)
 
-    // Update vite.config.mjs / .mts
-    const viteConfigPath = join(cwd, `vite.config.m${ext}`)
+    // Update vite.config.mts
+    const viteConfigPath = join(cwd, 'vite.config.mts')
     if (existsSync(viteConfigPath)) {
       const viteMod = await loadFile(viteConfigPath)
 

--- a/packages/shared/src/features/tailwindcss.ts
+++ b/packages/shared/src/features/tailwindcss.ts
@@ -10,7 +10,7 @@ const RE_STYLES = /\/\/ Styles/g
 
 export const tailwindcss: Feature = {
   name: 'tailwindcss',
-  apply: async ({ cwd, pkg, isTypescript, isNuxt, type }) => {
+  apply: async ({ cwd, pkg, isNuxt, type }) => {
     if (type === 'vuetify' && !isNuxt) {
       return
     }
@@ -34,8 +34,7 @@ export const tailwindcss: Feature = {
       pkg.devDependencies['tailwindcss'] = rootPkg.dependencies['tailwindcss']
       pkg.devDependencies['@tailwindcss/vite'] = rootPkg.dependencies['@tailwindcss/vite']
 
-      const ext = isTypescript ? 'ts' : 'js'
-      const viteConfigPath = join(cwd, `vite.config.m${ext}`)
+      const viteConfigPath = join(cwd, 'vite.config.mts')
       const mod = await loadFile(viteConfigPath)
 
       addVitePlugin(mod, {

--- a/packages/shared/src/features/unocss.ts
+++ b/packages/shared/src/features/unocss.ts
@@ -9,7 +9,7 @@ import rootPkg from './dependencies/package.json' with { type: 'json' }
 const RE_STYLES = /\/\/ Styles/g
 
 async function applyUnocssBase (
-  { cwd, pkg, isTypescript, isNuxt }: FeatureContext,
+  { cwd, pkg, isNuxt }: FeatureContext,
   options: { presetVuetify?: boolean } = {},
 ) {
   pkg.devDependencies = pkg.devDependencies || {}
@@ -42,8 +42,7 @@ async function applyUnocssBase (
     return
   }
 
-  const ext = isTypescript ? 'ts' : 'js'
-  const viteConfigPath = join(cwd, `vite.config.m${ext}`)
+  const viteConfigPath = join(cwd, 'vite.config.mts')
   const mod = await loadFile(viteConfigPath)
 
   addVitePlugin(mod, {

--- a/packages/shared/src/functions/scaffold.ts
+++ b/packages/shared/src/functions/scaffold.ts
@@ -222,8 +222,22 @@ export async function scaffold (options: ScaffoldOptions, callbacks: ScaffoldCal
 
   await applySharedAssets(projectRoot, platform, type)
 
-  let pkg
-  pkg = await readPackageJSON(join(projectRoot, 'package.json'))
+  const pkgPath = join(projectRoot, 'package.json')
+  let pkg = await readPackageJSON(pkgPath)
+
+  // Convert the project to JavaScript *before* applying features. Templates are
+  // authored in TypeScript and conversion renames the whole tree (e.g.
+  // `src/plugins/index.ts` -> `.js`, `vite.config.mts` -> `.mjs`). Features
+  // target files by their final extension, so they must run against the
+  // already-converted project, otherwise they fail with ENOENT. Re-read the
+  // package.json afterwards so the in-memory copy reflects the dependency and
+  // script changes conversion writes to disk.
+  if (platform === 'vue' && !typescript) {
+    callbacks.onConvertStart?.()
+    await convertProjectToJS(projectRoot)
+    callbacks.onConvertEnd?.()
+    pkg = await readPackageJSON(pkgPath)
+  }
 
   callbacks.onConfigStart?.()
   if (features && features.length > 0) {
@@ -233,19 +247,9 @@ export async function scaffold (options: ScaffoldOptions, callbacks: ScaffoldCal
   callbacks.onConfigEnd?.()
 
   // Update package.json name
-  const pkgPath = join(projectRoot, 'package.json')
   if (existsSync(pkgPath)) {
-    if (!pkg) {
-      pkg = await readPackageJSON(pkgPath)
-    }
     pkg.name = name
     await writePackageJSON(pkgPath, pkg)
-  }
-
-  if (platform === 'vue' && !typescript) {
-    callbacks.onConvertStart?.()
-    await convertProjectToJS(projectRoot)
-    callbacks.onConvertEnd?.()
   }
 
   const projectDocsOptions = {

--- a/packages/shared/src/functions/scaffold.ts
+++ b/packages/shared/src/functions/scaffold.ts
@@ -225,20 +225,6 @@ export async function scaffold (options: ScaffoldOptions, callbacks: ScaffoldCal
   const pkgPath = join(projectRoot, 'package.json')
   let pkg = await readPackageJSON(pkgPath)
 
-  // Convert the project to JavaScript *before* applying features. Templates are
-  // authored in TypeScript and conversion renames the whole tree (e.g.
-  // `src/plugins/index.ts` -> `.js`, `vite.config.mts` -> `.mjs`). Features
-  // target files by their final extension, so they must run against the
-  // already-converted project, otherwise they fail with ENOENT. Re-read the
-  // package.json afterwards so the in-memory copy reflects the dependency and
-  // script changes conversion writes to disk.
-  if (platform === 'vue' && !typescript) {
-    callbacks.onConvertStart?.()
-    await convertProjectToJS(projectRoot)
-    callbacks.onConvertEnd?.()
-    pkg = await readPackageJSON(pkgPath)
-  }
-
   callbacks.onConfigStart?.()
   if (features && features.length > 0) {
     await applyFeatures(projectRoot, features, pkg, !!typescript, platform === 'nuxt', type)
@@ -250,6 +236,15 @@ export async function scaffold (options: ScaffoldOptions, callbacks: ScaffoldCal
   if (existsSync(pkgPath)) {
     pkg.name = name
     await writePackageJSON(pkgPath, pkg)
+  }
+
+  // Everything is scaffolded in TypeScript
+  // convert to JavaScript as the final step
+  if (platform === 'vue' && !typescript) {
+    callbacks.onConvertStart?.()
+    await convertProjectToJS(projectRoot)
+    callbacks.onConvertEnd?.()
+    pkg = await readPackageJSON(pkgPath)
   }
 
   const projectDocsOptions = {

--- a/packages/shared/src/utils/convertProjectToJS.ts
+++ b/packages/shared/src/utils/convertProjectToJS.ts
@@ -3,9 +3,21 @@ import { join } from 'pathe'
 import { readPackageJSON, writePackageJSON } from 'pkg-types'
 
 const RE_LANG_TS = /\s?lang="ts"/g
-const RE_APP_IMPORT = /import type { App } from 'vue'.*\n/
-const RE_APP_TYPE = /app: App/
 const RE_TS_EXT = /\.m?ts$/
+
+const RE_TYPE_IMPORT = /^[ \t]*import\s+type\b.*\r?\n/gm
+const RE_TYPE = String.raw`[A-Z][\w$.]*(?:<[^>]*>)?(?:\[\])?`
+const RE_AS_SATISFIES = new RegExp(String.raw`\s+(?:as|satisfies)\s+${RE_TYPE}`, 'g')
+const RE_DECL_ANNOTATION = new RegExp(String.raw`\b(const|let|var)(\s+[A-Za-z_$][\w$]*)\s*:\s*${RE_TYPE}(?=\s*=)`, 'g')
+const RE_PARAM_ANNOTATION = new RegExp(String.raw`(\(\s*[A-Za-z_$][\w$]*)\s*:\s*${RE_TYPE}(?=\s*[,)])`, 'g')
+
+function stripTypeScript (content: string) {
+  return content
+    .replace(RE_TYPE_IMPORT, '')
+    .replace(RE_AS_SATISFIES, '')
+    .replace(RE_DECL_ANNOTATION, '$1$2')
+    .replace(RE_PARAM_ANNOTATION, '$1')
+}
 
 export async function convertProjectToJS (projectRoot: string) {
   // 1. Remove TS specific config files
@@ -80,13 +92,7 @@ export async function convertProjectToJS (projectRoot: string) {
       content = content.replace(RE_LANG_TS, '')
       writeFileSync(filePath, content)
     } else if (filePath.endsWith('.ts') || filePath.endsWith('.mts')) {
-      let content = readFileSync(filePath, 'utf8')
-
-      // Special handling for plugins/index.ts
-      if (filePath.endsWith('plugins/index.ts')) {
-        content = content.replace(RE_APP_IMPORT, '')
-        content = content.replace(RE_APP_TYPE, 'app')
-      }
+      const content = stripTypeScript(readFileSync(filePath, 'utf8'))
 
       // Rename file
       const newPath = filePath.replace(RE_TS_EXT, match => match === '.mts' ? '.mjs' : '.js')

--- a/packages/shared/test/convertProjectToJS.test.ts
+++ b/packages/shared/test/convertProjectToJS.test.ts
@@ -1,0 +1,69 @@
+/* eslint-disable e18e/prefer-static-regex */
+import { cpSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'pathe'
+import { afterEach, describe, expect, it } from 'vitest'
+import { convertProjectToJS } from '../src/utils/convertProjectToJS'
+
+const TEMPLATES = resolve(__dirname, '../../../templates')
+const dirs: string[] = []
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function convertTemplate (name: string) {
+  const dir = mkdtempSync(join(tmpdir(), 'convert-'))
+  dirs.push(dir)
+  cpSync(join(TEMPLATES, name), dir, { recursive: true })
+  return dir
+}
+
+function read (dir: string, pattern: RegExp) {
+  const out: Record<string, string> = {}
+  const walk = (d: string) => {
+    for (const f of readdirSync(d)) {
+      const p = join(d, f)
+      if (statSync(p).isDirectory()) {
+        walk(p)
+      } else if (pattern.test(p)) {
+        out[p.slice(dir.length)] = readFileSync(p, 'utf8')
+      }
+    }
+  }
+  walk(dir)
+  return out
+}
+
+describe('convertProjectToJS', () => {
+  // The vue templates that go through TS->JS conversion.
+  for (const name of ['vue/base', 'vue/unocss-wind4', 'vue/unocss-vuetify', 'vue/tailwind']) {
+    it(`strips TS syntax from ${name}`, async () => {
+      const dir = convertTemplate(name)
+      await convertProjectToJS(dir)
+
+      // No source file is left as .ts/.mts.
+      expect(Object.keys(read(dir, /\.m?ts$/))).toEqual([])
+
+      // No TS-only syntax survives in the emitted JS.
+      for (const [file, content] of Object.entries(read(dir, /\.m?js$/))) {
+        expect(content, `${file} has a type-only import`).not.toMatch(/\bimport\s+type\b/)
+        expect(content, `${file} has a satisfies expression`).not.toMatch(/\bsatisfies\b/)
+        expect(content, `${file} has a type annotation`).not.toMatch(/:\s*[A-Z][\w$.]*(?:<[^>]*>)?(?:\[\])?\s*[=,)]/)
+        expect(content, `${file} has an as-cast`).not.toMatch(/\bas\s+[A-Z][\w$.]*</)
+      }
+    })
+  }
+
+  it('preserves runtime object literals and namespace imports', async () => {
+    const dir = convertTemplate('vue/unocss-wind4')
+    await convertProjectToJS(dir)
+    const uno = readFileSync(join(dir, 'uno.config.js'), 'utf8')
+    // object property that looks annotation-shaped must stay intact
+    expect(uno).toMatch(/breakpoint:\s*breakpoints\.forUnoCSS/)
+    // `import * as breakpoints` must not be mistaken for an `as` cast
+    expect(uno).toMatch(/import \* as breakpoints from/)
+  })
+})

--- a/packages/shared/test/convertProjectToJS.test.ts
+++ b/packages/shared/test/convertProjectToJS.test.ts
@@ -57,6 +57,18 @@ describe('convertProjectToJS', () => {
     })
   }
 
+  it('strips feature-copied SFCs (router overlaid on base)', async () => {
+    // Mirrors scaffold: base template + a feature's template files, converted
+    // as one final pass.
+    const dir = convertTemplate('vue/base')
+    cpSync(join(TEMPLATES, 'vue/router'), dir, { recursive: true })
+    await convertProjectToJS(dir)
+
+    for (const [file, content] of Object.entries(read(dir, /\.vue$/))) {
+      expect(content, `${file} kept lang="ts"`).not.toMatch(/lang="ts"/)
+    }
+  })
+
   it('preserves runtime object literals and namespace imports', async () => {
     const dir = convertTemplate('vue/unocss-wind4')
     await convertProjectToJS(dir)


### PR DESCRIPTION
fixes #12

### Problem
Scaffolding a **Vue + `--no-typescript`** project together with any feature crashed:

```
$ create-vuetify --platform=vue --no-typescript --router=file-router --features=pinia,eslint,i18n,mcp --no-interactive
◇  Failed to download template
Failed to create project: Error: ENOENT: no such file or directory, open '.../src/plugins/index.js'
```

### Root cause
Features resolve their target files by final extension — with `--no-typescript` they look for `src/plugins/index.js`, `vite.config.mjs`, etc. But in `scaffold()` the TypeScript→JavaScript conversion ran **after** `applyFeatures`, so at feature-application time only the template's `.ts`/`.mts` files existed. `magicast.loadFile('src/plugins/index.js')` then threw `ENOENT`.

### Fix
Move `convertProjectToJS` **before** `applyFeatures`, and re-read `package.json` afterwards so the in-memory copy reflects the dependency/script changes conversion writes to disk. Features now operate on the already-converted JS tree.

### Verification
- Added a regression row to the create matrix: `vue-js` + `--router=router --features=pinia,eslint,i18n`. It fails before the fix (ENOENT) and passes after.
- Full matrix (11 cases) passes.
- Manually inspected the generated JS project: no `.ts`/`.mts` remnants, `src/plugins/index.js` registers pinia/i18n/router, the `app: App` type is stripped, `eslint.config.js` has `ts: false`.
