### PR TITLE
chore(templates): fix v0 scaffold build, pin v0, modernize unplugin-fonts

### DIFF
--- a/templates/vue/base/package.json
+++ b/templates/vue/base/package.json
@@ -24,14 +24,9 @@
     "npm-run-all2": "^8.0.4",
     "sass-embedded": "^1.98.0",
     "typescript": "~5.9.3",
-    "unplugin-fonts": "^1.4.0",
+    "unplugin-fonts": "^2.0.0",
     "vite": "^8.0.0",
     "vite-plugin-vuetify": "^2.1.3",
     "vue-tsc": "^3.2.5"
-  },
-  "overrides": {
-    "unplugin-fonts": {
-      "vite": "^8.0.0"
-    }
   }
 }

--- a/templates/vue/tailwind/package.json
+++ b/templates/vue/tailwind/package.json
@@ -27,14 +27,9 @@
     "sass-embedded": "^1.98.0",
     "tailwindcss": "^4.2.1",
     "typescript": "~5.9.3",
-    "unplugin-fonts": "^1.4.0",
+    "unplugin-fonts": "^2.0.0",
     "vite": "^8.0.0",
     "vite-plugin-vuetify": "^2.1.3",
     "vue-tsc": "^3.2.5"
-  },
-  "overrides": {
-    "unplugin-fonts": {
-      "vite": "^8.0.0"
-    }
   }
 }

--- a/templates/vue/unocss-vuetify/package.json
+++ b/templates/vue/unocss-vuetify/package.json
@@ -28,14 +28,9 @@
     "typescript": "~5.9.3",
     "unocss": "^66.6.6",
     "unocss-preset-vuetify": "^0.2.1",
-    "unplugin-fonts": "^1.4.0",
+    "unplugin-fonts": "^2.0.0",
     "vite": "^8.0.0",
     "vite-plugin-vuetify": "^2.1.3",
     "vue-tsc": "^3.2.5"
-  },
-  "overrides": {
-    "unplugin-fonts": {
-      "vite": "^8.0.0"
-    }
   }
 }

--- a/templates/vue/unocss-wind4/package.json
+++ b/templates/vue/unocss-wind4/package.json
@@ -29,14 +29,9 @@
     "typescript": "~5.9.3",
     "unocss": "^66.6.6",
     "unocss-preset-vuetify": "^0.2.1",
-    "unplugin-fonts": "^1.4.0",
+    "unplugin-fonts": "^2.0.0",
     "vite": "^8.0.0",
     "vite-plugin-vuetify": "^2.1.3",
     "vue-tsc": "^3.2.5"
-  },
-  "overrides": {
-    "unplugin-fonts": {
-      "vite": "^8.0.0"
-    }
   }
 }

--- a/templates/vuetify0/base/package.json
+++ b/templates/vuetify0/base/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@fontsource/roboto": "^5.2.10",
-    "@vuetify/v0": "latest",
+    "@vuetify/v0": "^1.0.0-beta.1",
     "vue": "^3.5.30"
   },
   "devDependencies": {
@@ -20,15 +20,11 @@
     "@types/node": "^24.12.0",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vue/tsconfig": "^0.9.0",
+    "npm-run-all2": "^8.0.4",
     "typescript": "~5.9.3",
     "unocss": "^66.6.6",
-    "unplugin-fonts": "^1.4.0",
+    "unplugin-fonts": "^2.0.0",
     "vite": "^8.0.0",
     "vue-tsc": "^3.2.5"
-  },
-  "overrides": {
-    "unplugin-fonts": {
-      "vite": "^8.0.0"
-    }
   }
 }

--- a/templates/vuetify0/nuxt/package.json
+++ b/templates/vuetify0/nuxt/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@fontsource/roboto": "^5.2.10",
-    "@vuetify/v0": "latest",
+    "@vuetify/v0": "^1.0.0-beta.1",
     "nuxt": "^4.4.2",
     "vue": "^3.5.30"
   },


### PR DESCRIPTION
## What

Three scaffolding-side fixes, all in `templates/`. Surfaced while testing a fresh `create-vuetify0` project end-to-end.

### 1. `pnpm build` is broken on a fresh v0 scaffold (the important one)
`templates/vuetify0/base` has `"build": "run-p type-check \"build-only {@}\""` but **no `npm-run-all2`** in devDependencies — it was dropped when the template was forked from `vue/base` (which still carries it). Result: a freshly scaffolded v0 project fails immediately:

```
> run-p type-check "build-only {@}" --
sh: 1: run-p: not found
 ELIFECYCLE  Command failed.
```

Fix: add `"npm-run-all2": "^8.0.4"` (matching `vue/base`).

### 2. `@vuetify/v0: "latest"` → pinned
Both v0 templates floated on the `latest` dist-tag, which re-resolves on every fresh install and will silently cross breaking betas. Pinned to `^1.0.0-beta.1`, consistent with how `vue/base` pins `"vuetify": "^4.0.2"`.

### 3. Drop the `unplugin-fonts` vite-override hack
All five vue-based templates pin `unplugin-fonts@^1.4.0` (peer caps at vite 7) and patch it with an `overrides: { unplugin-fonts: { vite: ^8 } }` block — which emits an `unmet peer` warning on install. `unplugin-fonts@2.0.0` lists `vite ^8` as a peer natively, so the override is no longer needed. Bumped to `^2.0.0` and removed the `overrides` block.

## Files
- `templates/vuetify0/base` — A1 + A2 + A3
- `templates/vuetify0/nuxt` — A2
- `templates/vue/{base,tailwind,unocss-vuetify,unocss-wind4}` — A3

## Verification
Scaffolded a fresh project from these templates (`VUETIFY_CLI_TEMPLATES_PATH` → this branch), then:
- `pnpm install` — **no** `unmet peer` warning; `npm-run-all2@8.0.4` + `unplugin-fonts@2.0.0` installed
- `pnpm build` — **succeeds**: `run-p` → `vue-tsc` type-check + `vite build`, dist emitted, Roboto fonts bundle correctly

## Notes
- `^1.0.0-beta.1` uses a caret on a prerelease; happy to pin exact if you prefer during beta.
- A related cleanup was intentionally **left out**: `applyUnocssBase` (in `packages/shared/src/features/unocss.ts`) adds `@unocss/transformer-directives` for every unocss variant, but no generated unocss config wires `transformerDirectives()`. It's a dead dep in the v0/shortcuts path yet (latently) needed-but-unwired by `unocss-wind4`'s `@apply`. Those are opposite fixes in shared code, so it deserves its own PR rather than riding along here.