### PR TITLE
fix(analyze): classify lowercase create* factories as composables

### DIFF
--- a/packages/shared/src/functions/analyze.ts
+++ b/packages/shared/src/functions/analyze.ts
@@ -45,6 +45,9 @@ function getFeatureType (name: string, isType = false, importMap?: any): Feature
   if (RE_PLUGIN.test(name)) {
     return 'plugin'
   }
+  if (name.startsWith('create') && name.length > 6 && name.at(6)?.match(RE_COMPOSABLE)) {
+    return 'composable'
+  }
   if (RE_CONSTANT.test(name)) {
     return 'constant'
   }


### PR DESCRIPTION
## Summary

Surfaced by the `/mirror` audit reconciling the CLI against `@vuetify/v0` v1.

The shipped `@vuetify/v0` `dist/json/importMap.json` exposes only a `components` map — there is **no `composables` key**. So `analyze`'s `getFeatureType()` classifies composables purely by regex fallback. Lowercase `create*` factory names matched none of `RE_PLUGIN` / `RE_CONSTANT` / `RE_COMPONENT` and silently fell through to `util` — including the stable core (`createSelection`, `createSingle`, `createGroup`, `createModel`, `createNested`, `createStep`, `createContext`, `createTrinity`, `createRegistry`, …), ~30 composables in all.

## Fix

Add a `create*` → `composable` branch **after** the `RE_PLUGIN` check (so `createXxxPlugin` still classifies as `plugin`) and **before** `RE_CONSTANT`/`RE_COMPONENT`:

```ts
if (name.startsWith('create') && name.length > 6 && name.at(6)?.match(RE_COMPOSABLE)) {
  return 'composable'
}
```

Unaffected: `use*` composables (earlier branch), real components (importMap + uppercase), `to*` transformers (still `util`, acceptable), all-caps constants.

## Verification

Standalone replica of `getFeatureType` over representative names — all correct:
`createSelection/createSingle/createGroup/createModel/createContext/createTrinity/createRegistry` → `composable`; `createPlugin` → `plugin`; `Dialog`/`Tabs` (importMap) → `component`; `ID` → `constant`; `toArray`/`toHighlight` → `util`.

## Notes / follow-ups (not in this PR)

- **Root cause is upstream**: the real fix is v0 emitting a `composables` key into `importMap.json` so classification stops relying on the heuristic. This is a stopgap in the CLI.
- **Template pins** `templates/vuetify0/{base,nuxt}/package.json` pin `@vuetify/v0` at `^1.0.0-beta.1` — the caret floats across `beta.x` but won't auto-adopt a `1.0.0` rc/stable. Flag for an explicit bump at GA.

No milestone set — the repo has none defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)