### PR TITLE
fix(generate): do not clobber components alias on --dir

### DIFF
--- a/packages/shared/src/functions/generate.ts
+++ b/packages/shared/src/functions/generate.ts
@@ -63,7 +63,10 @@ export async function generateComponent (options: GenerateOptions) {
     files: [file],
     entry: file,
     title: pascal,
-    componentsDir: base,
+    // Only seed/update the project components alias when writing to the
+    // inventory default — an explicit --dir is one-shot and must not move
+    // later `add` / `refresh` destinations (e.g. into src/components/ui).
+    componentsDir: options.dir ? undefined : base,
   })
 
   return { path: relative(cwd, abs).split('\\').join('/'), name: pascal }


### PR DESCRIPTION
## Summary

`vuetify generate Foo --dir src/components/ui` was rewriting `vuetify.json` `aliases.components` to that path, so subsequent `add` / `refresh` landed under `ui/…`.

`--dir` is now one-shot; only the default components location updates the alias.

Found while walking the CLI guide against a live registry before merging docs PR vuetifyjs/0#794.

## Test plan

- [x] `generate MyCard` then `generate Btn --dir src/components/ui` → alias stays `src/components`
- [x] `refresh dialog` still writes `src/components/dialog`